### PR TITLE
Fix race condition when registering :exredis_hapi_default_client

### DIFF
--- a/lib/exredis/api.ex
+++ b/lib/exredis/api.ex
@@ -30,9 +30,14 @@ defmodule Exredis.Api do
   def defaultclient do
     case Process.whereis(:exredis_hapi_default_client) do
       nil ->
-        {:ok, pid} = Exredis.start_link
-        Process.register(pid, :exredis_hapi_default_client)
-        pid
+        try do
+          {:ok, pid} = Exredis.start_link
+          Process.register(pid, :exredis_hapi_default_client)
+
+          pid
+        rescue
+          ArgumentError -> Process.whereis(:exredis_hapi_default_client)
+        end
       pid -> pid
     end
   end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -353,4 +353,16 @@ defmodule ApiTest do
     assert (c[:c] |> R.get("key")) == :undefined
   end
 
+  describe "defaultclient/0" do
+    test "concurrently registering :exredis_hapi_default_client does not fail" do
+      with [pid] <- [Task.async(&R.defaultclient/0),
+                     Task.async(&R.defaultclient/0),
+                     Task.async(&R.defaultclient/0),
+                     Task.async(&R.defaultclient/0),
+                     Task.async(&R.defaultclient/0)] |> Enum.map(&Task.await/1)
+                                                     |> Enum.uniq do
+        assert is_pid(pid)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When more than 2 processes try concurrently to call Exredis.Api.defaultclient, only
one will manage to register the process name and the other will fail
with ArgumentError.

See: https://github.com/erlang/otp/blob/master/lib/stdlib/src/gen.erl#L301

on how gen_{server, fsm, ..} processes handle this issue.